### PR TITLE
Work around javascript weirdness by reordering functions

### DIFF
--- a/src/Code.ts
+++ b/src/Code.ts
@@ -29,13 +29,6 @@ minDate.setDate(today.getDate() - 15)
 const maxDate = new Date()
 maxDate.setDate(today.getDate() + 60)
 
-function transform(ev: Event): Event | null {
-  if(DELETE_ALL) return null
-  // no need to preserve old events
-  if(ev["endTime"] < yesterday) return null
-  return ev
-}
-
 type Event = { "startTime": Date, "endTime": Date }
 type ExistingEvent = { "startTime": Date, "endTime": Date, "delete": (() => void) }
 
@@ -47,8 +40,8 @@ function main() {
       "startTime": ev.getStartTime(),
       "endTime": ev.getEndTime()
     })).forEach (ev => {
-      const r = transform(ev)
-      if (r != null) evs.push(r)
+      const filtered = filter(ev)
+      if (filtered != null) evs.push(filtered)
     })
 
     return evs
@@ -92,6 +85,13 @@ function main() {
   }
 
   Logger.log("Done.")
+}
+
+function filter(ev: Event): Event | null {
+  if(DELETE_ALL) return null
+  // no need to preserve old events
+  if(ev["endTime"] < yesterday) return null
+  return ev
 }
 
 function partitionEvents(sourceEvents: Event[], existingEvents: ExistingEvent[]): [Event[], ExistingEvent[]] {


### PR DESCRIPTION
The commit bef826b added a welcome facility to discard old events, however something in the impl is not right.  Somehow an undefined object gets passed to transform() and it chokes when trying to find an endTime from it. Investigating in the debugger, it looks like somehow the function transform() was being called with a null argument at the point in the file it is defined, before the main() function even starts! I fixed this by moving the definition lower down, but man, so many things about javascript just make you go ugh..